### PR TITLE
Add startretries to AudioEncoder supervisor settings

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -706,6 +706,8 @@ class API():
                 param['name'] = data['name']
                 param['uniq_id'] = data['uniq_id']
                 param['description'] = data['description']
+                if 'supervisor_additional_options' in data:
+                    param['supervisor_additional_options'] = data['supervisor_additional_options']
                 if 'action' in param:
                     param.pop('action')
                 odr.append( param )

--- a/avt/__init__.py
+++ b/avt/__init__.py
@@ -350,7 +350,10 @@ class AVT():
         ClockSourceIdx = {'1':'internal', '3':'recoveredAesEbu', '4':'ntp'}
         ClockSource = self.get_oid_value('1.3.6.1.4.1.26196.10.3.11.10.40.10')
         if ClockSource['status'] == 0:
-            avt['ClockSource'] = ClockSourceIdx[ClockSource['data']]
+            try:
+                avt['ClockSource'] = ClockSourceIdx[ClockSource['data']]
+            except:
+                avt['ClockSource'] = 'ID not recognized (%s)' % (ClockSource['data'])
 
         Alarms = self.get_AE1AlarmsTable()
         if Alarms['status'] == 0:
@@ -400,7 +403,10 @@ class AVT():
         ClockSourceIdx = {'1':'internal', '2': 'external', '3':'recoveredAesEbu', '4':'ntp'}
         ClockSource = self.get_oid_value('1.3.6.1.4.1.26196.10.3.12.10.20.10.10')
         if ClockSource['status'] == 0:
-            avt['ClockSource'] = ClockSourceIdx[ClockSource['data']]
+            try:
+                avt['ClockSource'] = ClockSourceIdx[ClockSource['data']]
+            except:
+                avt['ClockSource'] = 'ID not recognized (%s)' % (ClockSource['data'])
 
         Alarms = self.get_AE4AlarmsTable()
         if Alarms['status'] == 0:

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -809,7 +809,8 @@ class Config():
                     supervisorConfig += "priority=10\n"
                     supervisorConfig += "user=odr\n"
                     supervisorConfig += "group=odr\n"
-                    supervisorConfig += "stderr_logfile=/var/log/supervisor/odr-padencoder-%s.log\n" % (odr['uniq_id'])
+                    supervisorConfig += "redirect_stderr=true\n"
+                    #supervisorConfig += "stderr_logfile=/var/log/supervisor/odr-padencoder-%s.log\n" % (odr['uniq_id'])
                     supervisorConfig += "stdout_logfile=/var/log/supervisor/odr-padencoder-%s.log\n" % (odr['uniq_id'])
                     supervisorConfig += "\n"
 
@@ -922,7 +923,8 @@ class Config():
                 supervisorConfig += "priority=10\n"
                 supervisorConfig += "user=odr\n"
                 supervisorConfig += "group=odr\n"
-                supervisorConfig += "stderr_logfile=/var/log/supervisor/odr-audioencoder-%s.log\n" % (odr['uniq_id'])
+                supervisorConfig += "redirect_stderr=true\n"
+                #supervisorConfig += "stderr_logfile=/var/log/supervisor/odr-audioencoder-%s.log\n" % (odr['uniq_id'])
                 supervisorConfig += "stdout_logfile=/var/log/supervisor/odr-audioencoder-%s.log\n" % (odr['uniq_id'])
                 supervisorConfig += "\n"
                 
@@ -959,7 +961,8 @@ class Config():
                     supervisorConfig += "priority=10\n"
                     supervisorConfig += "user=odr\n"
                     supervisorConfig += "group=odr\n"
-                    supervisorConfig += "stderr_logfile=/var/log/supervisor/slide-%s.log\n" % (odr['uniq_id'])
+                    supervisorConfig += "redirect_stderr=true\n"
+                    #supervisorConfig += "stderr_logfile=/var/log/supervisor/slide-%s.log\n" % (odr['uniq_id'])
                     supervisorConfig += "stdout_logfile=/var/log/supervisor/slide-%s.log\n" % (odr['uniq_id'])
                     supervisorConfig += "\n"
                 
@@ -983,7 +986,8 @@ class Config():
                         supervisorConfig += "priority=10\n"
                         supervisorConfig += "user=odr\n"
                         supervisorConfig += "group=odr\n"
-                        supervisorConfig += "stderr_logfile=/var/log/supervisor/adcast-%s.log\n" % (odr['uniq_id'])
+                        supervisorConfig += "redirect_stderr=true\n"
+                        #supervisorConfig += "stderr_logfile=/var/log/supervisor/adcast-%s.log\n" % (odr['uniq_id'])
                         supervisorConfig += "stdout_logfile=/var/log/supervisor/adcast-%s.log\n" % (odr['uniq_id'])
                         supervisorConfig += "\n"
                     

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -804,14 +804,25 @@ class Config():
                     supervisorConfig += "# %s\n" % (odr['name'])
                     supervisorConfig += "[program:odr-padencoder-%s]\n" % (odr['uniq_id'])
                     supervisorConfig += "command=%s" % (command)
-                    supervisorConfig += "autostart=%s\n" % (odr['autostart'])
-                    supervisorConfig += "autorestart=true\n"
-                    supervisorConfig += "priority=10\n"
-                    supervisorConfig += "user=odr\n"
-                    supervisorConfig += "group=odr\n"
-                    supervisorConfig += "redirect_stderr=true\n"
-                    #supervisorConfig += "stderr_logfile=/var/log/supervisor/odr-padencoder-%s.log\n" % (odr['uniq_id'])
-                    supervisorConfig += "stdout_logfile=/var/log/supervisor/odr-padencoder-%s.log\n" % (odr['uniq_id'])
+                    
+                    # -- default parameters
+                    supervisorConfigParam = {}
+                    supervisorConfigParam['autostart'] = odr['autostart']
+                    supervisorConfigParam['autorestart'] = "true"
+                    supervisorConfigParam['priority'] = "10"
+                    supervisorConfigParam['user'] = "odr"
+                    supervisorConfigParam['group'] = "odr"
+                    supervisorConfigParam['redirect_stderr'] = "true"
+                    supervisorConfigParam['stdout_logfile'] = "/var/log/supervisor/odr-padencoder-%s.log" % (odr['uniq_id'])
+                    
+                    # -- override default parameters or add additional parameters
+                    if 'supervisor_additional_options' in odr:
+                        for key in odr['supervisor_additional_options'].keys():
+                            supervisorConfigParam[key] = odr['supervisor_additional_options'][key]
+                    
+                    # -- generate final padencoder supervisor configuration
+                    for key in supervisorConfigParam.keys():
+                        supervisorConfig += "%s=%s\n" % (key, supervisorConfigParam[key])
                     supervisorConfig += "\n"
 
                 # Write supervisor audioencoder section
@@ -918,14 +929,25 @@ class Config():
                 supervisorConfig += "# %s\n" % (odr['name'])
                 supervisorConfig += "[program:odr-audioencoder-%s]\n" % (odr['uniq_id'])
                 supervisorConfig += "command=%s" % (command)
-                supervisorConfig += "autostart=%s\n" % (odr['autostart'])
-                supervisorConfig += "autorestart=true\n"
-                supervisorConfig += "priority=10\n"
-                supervisorConfig += "user=odr\n"
-                supervisorConfig += "group=odr\n"
-                supervisorConfig += "redirect_stderr=true\n"
-                #supervisorConfig += "stderr_logfile=/var/log/supervisor/odr-audioencoder-%s.log\n" % (odr['uniq_id'])
-                supervisorConfig += "stdout_logfile=/var/log/supervisor/odr-audioencoder-%s.log\n" % (odr['uniq_id'])
+                
+                # -- default parameters
+                supervisorConfigParam = {}
+                supervisorConfigParam['autostart'] = odr['autostart']
+                supervisorConfigParam['autorestart'] = "true"
+                supervisorConfigParam['priority'] = "10"
+                supervisorConfigParam['user'] = "odr"
+                supervisorConfigParam['group'] = "odr"
+                supervisorConfigParam['redirect_stderr'] = "true"
+                supervisorConfigParam['stdout_logfile'] = "/var/log/supervisor/odr-audioencoder-%s.log" % (odr['uniq_id'])
+                    
+                # -- override default parameters or add additional parameters
+                if 'supervisor_additional_options' in odr:
+                    for key in odr['supervisor_additional_options'].keys():
+                        supervisorConfigParam[key] = odr['supervisor_additional_options'][key]
+                
+                # -- generate final audioencoder supervisor configuration
+                for key in supervisorConfigParam.keys():
+                    supervisorConfig += "%s=%s\n" % (key, supervisorConfigParam[key])
                 supervisorConfig += "\n"
                 
                 # Write supervisor slide_mgnt section
@@ -956,15 +978,26 @@ class Config():
                     supervisorConfig += "# %s\n" % (odr['name'])
                     supervisorConfig += "[program:slide-mgnt-%s]\n" % (odr['uniq_id'])
                     supervisorConfig += "command=%s" % (command)
-                    supervisorConfig += "autostart=%s\n" % (odr['autostart'])
-                    supervisorConfig += "autorestart=true\n"
-                    supervisorConfig += "priority=10\n"
-                    supervisorConfig += "user=odr\n"
-                    supervisorConfig += "group=odr\n"
-                    supervisorConfig += "redirect_stderr=true\n"
-                    #supervisorConfig += "stderr_logfile=/var/log/supervisor/slide-%s.log\n" % (odr['uniq_id'])
-                    supervisorConfig += "stdout_logfile=/var/log/supervisor/slide-%s.log\n" % (odr['uniq_id'])
+                    # -- default parameters
+                    supervisorConfigParam = {}
+                    supervisorConfigParam['autostart'] = odr['autostart']
+                    supervisorConfigParam['autorestart'] = "true"
+                    supervisorConfigParam['priority'] = "10"
+                    supervisorConfigParam['user'] = "odr"
+                    supervisorConfigParam['group'] = "odr"
+                    supervisorConfigParam['redirect_stderr'] = "true"
+                    supervisorConfigParam['stdout_logfile'] = "/var/log/supervisor/slide-%s.log" % (odr['uniq_id'])
+                    
+                    # -- override default parameters or add additional parameters
+                    if 'supervisor_additional_options' in odr:
+                        for key in odr['supervisor_additional_options'].keys():
+                            supervisorConfigParam[key] = odr['supervisor_additional_options'][key]
+                    
+                    # -- generate final slide_mgnt supervisor configuration
+                    for key in supervisorConfigParam.keys():
+                        supervisorConfig += "%s=%s\n" % (key, supervisorConfigParam[key])
                     supervisorConfig += "\n"
+
                 
                 # Write supervisor adcast section
                 if odr['padenc']['enable'] == 'true'\
@@ -981,15 +1014,26 @@ class Config():
                         supervisorConfig += "# %s\n" % (odr['name'])
                         supervisorConfig += "[program:adcast-%s]\n" % (odr['uniq_id'])
                         supervisorConfig += "command=%s" % (command)
-                        supervisorConfig += "autostart=%s\n" % (odr['autostart'])
-                        supervisorConfig += "autorestart=true\n"
-                        supervisorConfig += "priority=10\n"
-                        supervisorConfig += "user=odr\n"
-                        supervisorConfig += "group=odr\n"
-                        supervisorConfig += "redirect_stderr=true\n"
-                        #supervisorConfig += "stderr_logfile=/var/log/supervisor/adcast-%s.log\n" % (odr['uniq_id'])
-                        supervisorConfig += "stdout_logfile=/var/log/supervisor/adcast-%s.log\n" % (odr['uniq_id'])
+                        # -- default parameters
+                        supervisorConfigParam = {}
+                        supervisorConfigParam['autostart'] = odr['autostart']
+                        supervisorConfigParam['autorestart'] = "true"
+                        supervisorConfigParam['priority'] = "10"
+                        supervisorConfigParam['user'] = "odr"
+                        supervisorConfigParam['group'] = "odr"
+                        supervisorConfigParam['redirect_stderr'] = "true"
+                        supervisorConfigParam['stdout_logfile'] = "/var/log/supervisor/adcast-%s.log" % (odr['uniq_id'])
+                        # -- override default parameters or add additional parameters
+                        if 'supervisor_additional_options' in odr:
+                            for key in odr['supervisor_additional_options'].keys():
+                                supervisorConfigParam[key] = odr['supervisor_additional_options'][key]
+                        
+                        # -- generate final adcast supervisor configuration
+                        for key in supervisorConfigParam.keys():
+                            supervisorConfig += "%s=%s\n" % (key, supervisorConfigParam[key])
                         supervisorConfig += "\n"
+                    
+
                     
 
         try:

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -934,6 +934,7 @@ class Config():
                 supervisorConfigParam = {}
                 supervisorConfigParam['autostart'] = odr['autostart']
                 supervisorConfigParam['autorestart'] = "true"
+                supervisorConfigParam['startretries'] = "100000"     #To ensure station stays on air even with bad internet connection
                 supervisorConfigParam['priority'] = "10"
                 supervisorConfigParam['user'] = "odr"
                 supervisorConfigParam['group'] = "odr"

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -496,6 +496,13 @@ class Config():
                     coder['source']['stream_url'] = coder['source']['url']
                     del coder['source']['url']
                     print ('- rename url to stream_url in configuration file')
+                if not 'stream_url' in coder['source']:
+                    coder['source']['stream_url'] = ''
+                    print ('- add stream_url in configuration file')
+                if not 'stream_lib' in coder['source']:
+                    coder['source']['stream_lib'] = 'vlc'
+                    print ('- add stream_lib in configuration file')
+                    
             if 'output' in coder:
                 if 'zmq_output' in coder['output']:
                     print ('- rename zmq_output to output in configuration file')

--- a/static/js/odr-encoderconfig.js
+++ b/static/js/odr-encoderconfig.js
@@ -201,6 +201,11 @@ function requestConfiguration(reload=false) {
                             if ( form_key == 'padenc_dls_fifo_file') { form_key='padenc_dls_file' }
                             if ( form_key == 'source_device') { form_key='source_alsa_device' }
                             if ( form_key == 'source_url') { form_key='source_stream_url' }
+                            
+                            // -- Ignore 'supervisor_additional_options'
+                            if ( section_key == 'supervisor_additional_options') {
+                                return;
+                            }
 
                             if ( $('#'+form_key).prop('tagName') == 'INPUT' ) {
                                 $('#'+form_key).val(param_val);
@@ -372,7 +377,7 @@ function setConfiguration() {
             }
             param['adcast'] = adcast
         }
-
+        
         $.ajax({
             type: "POST",
             url: "/api/setConfig",


### PR DESCRIPTION
To avoid 'FATAL state, too many start retries too quickly' log entries on streams with bad internet connection